### PR TITLE
Define RCTJSNavigationScheme since it has been removed from React Native

### DIFF
--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -16,6 +16,8 @@
 
 #import <objc/runtime.h>
 
+NSString *const RCTJSNavigationScheme = @"react-js-navigation";
+
 // runtime trick to remove or replace WKWebView keyboard default toolbar
 // see: http://stackoverflow.com/questions/19033292/ios-7-uiwebview-keyboard-issue/19042279#19042279
 @interface _SwizzleHelperWK : NSObject @end


### PR DESCRIPTION
This is necessary for running with React Native 0.61