### PR TITLE
React Native 0.72+ compatibility fix (part 2)

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -4,15 +4,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactNative, {
   requireNativeComponent,
-  EdgeInsetsPropType,
   StyleSheet,
   UIManager,
   View,
-  ViewPropTypes,
   NativeModules,
   Text,
   ActivityIndicator
 } from 'react-native';
+import { EdgeInsetsPropType, ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import invariant from 'fbjs/lib/invariant';

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "url": "https://github.com/CRAlpha/react-native-wkwebview/issues"
   },
   "dependencies": {
-    "fbjs": "^0.8.3"
+    "fbjs": "^0.8.3",
+    "deprecated-react-native-prop-types": "^5.0.0"
   },
   "description": "React Native WKWebView for iOS",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/CRAlpha/react-native-wkwebview/issues"
   },
   "dependencies": {
-    "fbjs": "^0.8.3",
+    "fbjs": "^3.0.5",
     "deprecated-react-native-prop-types": "^5.0.0"
   },
   "description": "React Native WKWebView for iOS",


### PR DESCRIPTION
## Description

This PR fixes deprecated prop types errors by switching to a dedicated `deprecated-react-native-prop-types` dependency. Also it updated the `fbjs` dependency.