### PR TITLE
React Native 0.72+ compatibility fix (part 3)

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -304,7 +304,7 @@ class WKWebView extends React.Component {
     startInLoadingState: true,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.startInLoadingState) {
       this.setState({ viewState: WebViewState.LOADING });
     }

--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -201,10 +201,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     if (rootView) {
       UIView *accessoryView = [strongSelf.bridge.uiManager viewForNativeID:nativeID
                                                                withRootTag:rootView.reactTag];
-      // For backwards compatibility with React Native 0.55.4, use the content view.
-      if ([accessoryView respondsToSelector:@selector(content)]) {
-        accessoryView = [accessoryView valueForKey:@"content"];
-      }
       if ([accessoryView respondsToSelector:@selector(inputAccessoryView)]) {
         [strongSelf swizzleWebView];
         strongSelf.inputAccessoryView = [accessoryView valueForKey:@"inputAccessoryView"];

--- a/react-native-wkwebview.podspec
+++ b/react-native-wkwebview.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/jspeth/react-native-wkwebview"
 
   s.license      = "MIT"
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "13.4"
 
   s.source       = { :git => "https://github.com/jspeth/react-native-wkwebview.git", :branch => "master" }
 


### PR DESCRIPTION
## Description

This PR adds React 18 compatibility, bumps min iOS version to 13.4 and deletes unused code