### PR TITLE
`_SwizzleHelperWK` rename

### DIFF
--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -20,8 +20,8 @@ NSString *const RCTJSNavigationScheme = @"react-js-navigation";
 
 // runtime trick to remove or replace WKWebView keyboard default toolbar
 // see: http://stackoverflow.com/questions/19033292/ios-7-uiwebview-keyboard-issue/19042279#19042279
-@interface _SwizzleHelperWK : NSObject @end
-@implementation _SwizzleHelperWK
+@interface _SwizzleHelperOldWK : NSObject @end
+@implementation _SwizzleHelperOldWK
 -(id)inputAccessoryView
 {
   UIView *webView = (UIView *)self;
@@ -226,7 +226,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   
   if(subview == nil) return;
   
-  NSString* name = [NSString stringWithFormat:@"%@_SwizzleHelperWK", subview.class.superclass];
+  NSString* name = [NSString stringWithFormat:@"%@_SwizzleHelperOldWK", subview.class.superclass];
   Class newClass = NSClassFromString(name);
   
   if(newClass == nil)
@@ -234,7 +234,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     newClass = objc_allocateClassPair(subview.class, [name cStringUsingEncoding:NSASCIIStringEncoding], 0);
     if(!newClass) return;
     
-    Method method = class_getInstanceMethod([_SwizzleHelperWK class], @selector(inputAccessoryView));
+    Method method = class_getInstanceMethod([_SwizzleHelperOldWK class], @selector(inputAccessoryView));
     class_addMethod(newClass, @selector(inputAccessoryView), method_getImplementation(method), method_getTypeEncoding(method));
     
     objc_registerClassPair(newClass);


### PR DESCRIPTION
## Description

This PR renames `_SwizzleHelperWK` to eliminate symbol duplication with the `react-native-webview` implementation.